### PR TITLE
Ditch Slack alerts

### DIFF
--- a/patreon-mailchimp/create.js
+++ b/patreon-mailchimp/create.js
@@ -70,19 +70,17 @@ function updateMailchimp(body) {
     body: JSON.stringify(body),
   };
 
+  // Debugging
+  console.log(body);
+
   fetch(endpoint, options)
     .then(function(res) {
       return res.json();
     })
     .then(function(json) {
-      slackAlert();
-      var output = json;
-      callback(null, output);
+      callback(null, {success: message});
     })
     .catch(callback);
-
-  // Debugging
-  console.log(message);
 }
 
 /**
@@ -100,20 +98,4 @@ function setGroup(selectedGroup) {
   }
 
   return { interests: groupsToSend };
-}
-
-/**
- * Post to Slack whenever something happens on Zapier.
- * Very rudimentary logging/debugging. If issues (timeouts, etc) happen often,
- * we'll need to implement more robust error catching, alerting, and messaging.
- */
-function slackAlert() {
-  const webhook = '<slack_hook_here>';
-
-  fetch(webhook, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({text: `New Patron! ${message}`}),
-  })
-    .catch(callback);
 }

--- a/patreon-mailchimp/delete.js
+++ b/patreon-mailchimp/delete.js
@@ -42,29 +42,8 @@ function deleteFromMailchimp() {
       return res.json();
     })
     .then(function(json) {
-      slackAlert();
-      var output = json;
-      callback(null, output);
+      callback(null, {success: message});
     })
-    .catch(callback);
-
-  // Debugging
-  console.log(message);
-}
-
-/**
- * Post to Slack whenever something happens on Zapier.
- * Very rudimentary logging/debugging. If issues (timeouts, etc) happen often,
- * we'll need to implement more robust error catching, alerting, and messaging.
- */
-function slackAlert() {
-  const webhook = '<slack_hook_here>';
-
-  fetch(webhook, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({text: `Patron unpledged :cry: ${message}`}),
-  })
     .catch(callback);
 }
 

--- a/patreon-mailchimp/update.js
+++ b/patreon-mailchimp/update.js
@@ -61,19 +61,17 @@ function updateMailchimp(body) {
     body: JSON.stringify(body),
   };
 
+  // Debugging
+  console.log(body);
+
   fetch(endpoint, options)
     .then(function(res) {
       return res.json();
     })
     .then(function(json) {
-      slackAlert();
-      var output = json;
-      callback(null, output);
+      callback(null, {success: message);
     })
     .catch(callback);
-
-  // Debugging
-  console.log(message);
 }
 
 /**
@@ -91,22 +89,6 @@ function setGroup(selectedGroup) {
   }
 
   return { interests: groupsToSend };
-}
-
-/**
- * Post to Slack whenever something happens on Zapier.
- * Very rudimentary logging/debugging. If issues (timeouts, etc) happen often,
- * we'll need to implement more robust error catching, alerting, and messaging.
- */
-function slackAlert() {
-  const webhook = '<slack_hook_here>';
-
-  fetch(webhook, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({text: `Patron changed! ${message}`}),
-  })
-    .catch(callback);
 }
 
 /**


### PR DESCRIPTION
They're not really working anyway, and we currently have a nonprofit sub that allows us to do a 3rd Slack notification via Zapier multi-steps.